### PR TITLE
FIX warning: unused parameter

### DIFF
--- a/cabot_common/src/footprint_publisher.cpp
+++ b/cabot_common/src/footprint_publisher.cpp
@@ -177,7 +177,7 @@ private:
   }
 
   rcl_interfaces::msg::SetParametersResult param_set_callback(
-    const std::vector<rclcpp::Parameter> & params)
+    const std::vector<rclcpp::Parameter> /*& params*/)
   {
     rcl_interfaces::msg::SetParametersResult result;
     result.successful = true;


### PR DESCRIPTION
The following warning was addressed.
```
--- stderr: cabot_common                                                                                    
/home/developer/loc_ws/src/cabot_common/src/footprint_publisher.cpp: In member function ‘rcl_interfaces::msg::SetParametersResult FootprintPublisher::param_set_callback(const std::vector<rclcpp::Parameter>&)’:
/home/developer/loc_ws/src/cabot_common/src/footprint_publisher.cpp:180:44: warning: unused parameter ‘params’ [-Wunused-parameter]
  180 |     const std::vector<rclcpp::Parameter> & params)
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```