### PR TITLE
add dependency on livox_laser_simulation_ros2 for Livox mid-70 simulation

### DIFF
--- a/dependency.repos
+++ b/dependency.repos
@@ -13,6 +13,11 @@ repositories:
     type: git
     url: https://github.com/DroneBase/livox_ros2_driver.git
     version: 72cb73e
+  docker/humble-custom/livox_laser_simulation_ros2:
+    # not distributed
+    type: git
+    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
+    version: cabot-main
   docker/humble-custom/people:
     # not distributed
     type: git


### PR DESCRIPTION
add dependency on livox_laser_simulation_ros2 for Livox mid-70 simulation

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>