### PR TITLE
add a service to clear TF buffer in lookup_transform_service

### DIFF
--- a/cabot_common/CMakeLists.txt
+++ b/cabot_common/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(people_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -70,6 +71,7 @@ add_library(lookup_transform_service SHARED
 ament_target_dependencies(lookup_transform_service
   cabot_msgs
   geometry_msgs
+  std_srvs
   tf2_geometry_msgs
   tf2_ros
   rclcpp

--- a/cabot_common/src/lookup_transform_service.cpp
+++ b/cabot_common/src/lookup_transform_service.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include "rclcpp/rclcpp.hpp"
 #include "cabot_msgs/srv/lookup_transform.hpp"
+#include <std_srvs/srv/trigger.hpp>
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
@@ -40,6 +41,9 @@ public:
     service_ = this->create_service<cabot_msgs::srv::LookupTransform>(
       "lookup_transform",
       std::bind(&LookupTransformServiceNode::lookupTransform, this, std::placeholders::_1, std::placeholders::_2));
+    clear_buffer_service_ = this->create_service<std_srvs::srv::Trigger>(
+      "clear_transform_buffer",
+      std::bind(&LookupTransformServiceNode::clearTransformBuffer, this, std::placeholders::_1, std::placeholders::_2));
     RCLCPP_INFO(rclcpp::get_logger("lookup_transform"), "Ready to lookup transform");
   }
 
@@ -70,10 +74,19 @@ public:
     }
   }
 
+  void clearTransformBuffer(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+  {
+    buffer_.clear();
+    response->success = true;
+  }
+
 private:
   tf2_ros::Buffer buffer_;
   tf2_ros::TransformListener listener_;
   rclcpp::Service<cabot_msgs::srv::LookupTransform>::SharedPtr service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr clear_buffer_service_;
 };  // class LookupTransformServiceNode
 
 }  // namespace CaBot


### PR DESCRIPTION
This fix add `/clear_transform_buffer` service to allow other nodes to clear buffered TF in lookup_transform_service node.