### PR TITLE
Suppress a build warning in lookup_transform_service by adding maybe_unused attribute

### DIFF
--- a/cabot_common/src/lookup_transform_service.cpp
+++ b/cabot_common/src/lookup_transform_service.cpp
@@ -75,7 +75,7 @@ public:
   }
 
   void clearTransformBuffer(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    [[maybe_unused]] const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
     std::shared_ptr<std_srvs::srv::Trigger::Response> response)
   {
     buffer_.clear();


### PR DESCRIPTION
This commit suppresses a build warning
```
--- stderr: cabot_common
/home/developer/driver_ws/src/cabot_common/src/lookup_transform_service.cpp: In member function ‘void CaBot::LookupTransformServiceNode::clearTransformBuffer(std::shared_ptr<std_srvs::srv::Trigger_Request_<std::allocator<void> > >, std::shared_ptr<std_srvs::srv::Trigger_Response_<std::allocator<void> > >)’:
Finished <<< cabot_common [50.8s]
/home/developer/driver_ws/src/cabot_common/src/lookup_transform_service.cpp:78:60: warning: unused parameter ‘request’ [-Wunused-parameter]
   78 |     const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
---
```