### PR TITLE
Kayukawa/add poselog2

### DIFF
--- a/cabot_msgs/CMakeLists.txt
+++ b/cabot_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 rosidl_generate_interfaces(${PROJECT_NAME}
   msg/Anchor.msg
   msg/PoseLog.msg
+  msg/PoseLog2.msg
   msg/Log.msg
   msg/StopReason.msg
   srv/Speak.srv

--- a/cabot_msgs/msg/PoseLog2.msg
+++ b/cabot_msgs/msg/PoseLog2.msg
@@ -23,7 +23,5 @@ geometry_msgs/Pose pose
 float64 lat
 float64 lng
 float64 global_rotate
-float64 anchor_lat
-float64 anchor_lng
-float64 anchor_rotate
+cabot_msgs/Anchor anchor
 int32 floor

--- a/cabot_msgs/msg/PoseLog2.msg
+++ b/cabot_msgs/msg/PoseLog2.msg
@@ -1,0 +1,29 @@
+# Copyright (c) 2025  Carnegie Mellon University
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+std_msgs/Header header
+geometry_msgs/Pose pose
+float64 lat
+float64 lng
+float64 global_rotate
+float64 anchor_lat
+float64 anchor_lng
+float64 anchor_rotate
+int32 floor


### PR DESCRIPTION
This PR adds a new message PoseLog2 in cabot_msgs, which extends PoseLog by including:
- Anchor information
- the robot's global rotation (`global_rotate`) calculated based on the anchor and orientation
  - The `global_rotate` represents the robot's orientation relative to true north, expressed in degrees from 0 to 360 (clockwise, with 0 = true north).
- Related issue
  - https://github.com/CMU-cabot/TODO-Consortium/issues/971