### PR TITLE
add grid_image_throttle node and a launch file for three camera throttle

### DIFF
--- a/cabot_common/CMakeLists.txt
+++ b/cabot_common/CMakeLists.txt
@@ -19,7 +19,10 @@ find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+# find_package(topic_tools REQUIRED)
 find_package(visualization_msgs REQUIRED)
+
+install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch)
 
 add_executable(footprint_publisher
   src/footprint_publisher.cpp
@@ -95,6 +98,29 @@ ament_target_dependencies(log_redirector_node
   rcl_interfaces
 )
 
+# grid throttle node is not built by default because it requires an additional dependency (topic_tools)
+# add_executable(grid_throttle_node
+#   src/grid_throttle.cpp
+# )
+
+# ament_target_dependencies(grid_throttle_node
+#   rclcpp
+#   sensor_msgs
+#   std_msgs
+#   topic_tools
+# )
+
+# grid image throttle
+add_executable(grid_image_throttle_node
+  src/grid_image_throttle.cpp
+)
+
+ament_target_dependencies(grid_image_throttle_node
+  rclcpp
+  sensor_msgs
+  std_msgs
+)
+
 install(PROGRAMS
   scripts/footprint_publisher.py
   scripts/map_loader.py
@@ -107,6 +133,8 @@ install(TARGETS
   lookup_transform_service
   people_vis_node
   log_redirector_node
+  # grid_throttle_node
+  grid_image_throttle_node
   RUNTIME DESTINATION lib/${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/cabot_common/launch/three_image_throttle.launch.py
+++ b/cabot_common/launch/three_image_throttle.launch.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025  IBM Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import SetEnvironmentVariable
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnShutdown
+from launch.logging import launch_config
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.actions import SetParameter
+from cabot_common.launch import AppendLogDirPrefix
+
+
+def generate_launch_description():
+    output = {'stderr': {'log'}}
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    camera1 = LaunchConfiguration('camera1')
+    camera2 = LaunchConfiguration('camera2')
+    camera3 = LaunchConfiguration('camera3')
+    input_topic_name = LaunchConfiguration('input_topic_name')
+    output_topic_name = LaunchConfiguration('output_topic_name')
+    compressed = LaunchConfiguration('compressed')
+    throttle_hz = LaunchConfiguration('throttle_hz')
+    max_sync_interval = LaunchConfiguration('max_sync_interval')
+
+    return LaunchDescription([
+        # save all log file in the directory where the launch.log file is saved
+        SetEnvironmentVariable('ROS_LOG_DIR', launch_config.log_dir),
+        # append prefix name to the log directory for convenience
+        RegisterEventHandler(OnShutdown(on_shutdown=[AppendLogDirPrefix("cabot_common")])),
+
+        DeclareLaunchArgument('use_sim_time', default_value='false'),
+        DeclareLaunchArgument('camera1', default_value='/camera1'),
+        DeclareLaunchArgument('camera2', default_value='/camera2'),
+        DeclareLaunchArgument('camera3', default_value='/camera3'),
+        DeclareLaunchArgument('input_topic_name', default_value='/image_raw/compressed'),
+        DeclareLaunchArgument('output_topic_name', default_value='/image_throttled/compressed'),
+        DeclareLaunchArgument('compressed', default_value='true'),
+        DeclareLaunchArgument('throttle_hz', default_value='1.0'),
+        DeclareLaunchArgument('max_sync_interval', default_value='0.2'),
+
+        SetParameter('use_sim_time', use_sim_time),
+
+        # run three grid image throttle nodes
+        Node(
+            package='cabot_common',
+            executable='grid_image_throttle_node',
+            name='grid_image_throttle_node_1',
+            parameters=[
+                    {
+                        'throttle_hz': throttle_hz,
+                        'max_sync_interval': max_sync_interval,
+                        'compressed': compressed,
+                        'input_topic': [camera1, input_topic_name],
+                        'output_topic': [camera1, output_topic_name],
+                    },
+            ],
+            output=output,
+        ),
+        Node(
+            package='cabot_common',
+            executable='grid_image_throttle_node',
+            name='grid_image_throttle_node_2',
+            parameters=[
+                    {
+                        'throttle_hz': throttle_hz,
+                        'max_sync_interval': max_sync_interval,
+                        'compressed': compressed,
+                        'input_topic': [camera2, input_topic_name],
+                        'output_topic': [camera2, output_topic_name],
+                    },
+            ],
+            output=output,
+        ),
+        Node(
+            package='cabot_common',
+            executable='grid_image_throttle_node',
+            name='grid_image_throttle_node_3',
+            parameters=[
+                    {
+                        'throttle_hz': throttle_hz,
+                        'max_sync_interval': max_sync_interval,
+                        'compressed': compressed,
+                        'input_topic': [camera3, input_topic_name],
+                        'output_topic': [camera3, output_topic_name],
+                    },
+            ],
+            output=output,
+        ),
+    ])

--- a/cabot_common/src/grid_image_throttle.cpp
+++ b/cabot_common/src/grid_image_throttle.cpp
@@ -1,0 +1,155 @@
+// Copyright (c) 2025  IBM Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <any>
+#include <cmath>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/msg/image.hpp>
+
+using sensor_msgs::msg::CameraInfo;
+using sensor_msgs::msg::CompressedImage;
+using sensor_msgs::msg::Image;
+
+class GridImageThrottleNode : public rclcpp::Node
+{
+public:
+  explicit GridImageThrottleNode(const rclcpp::NodeOptions & options)
+  : Node("grid_image_throttle", options)
+  {
+    compressed_ = declare_parameter<bool>("compressed", false);
+    input_topic_ = declare_parameter<std::string>("input_topic");
+    output_topic_ = declare_parameter<std::string>("output_topic", input_topic_ + "_throttle");
+    max_sync_interval_ = declare_parameter<double>("max_sync_interval", 0.2);
+    throttle_hz_ = declare_parameter<double>("throttle_hz", 1.0);
+    log_interval_ms_ = declare_parameter<int>("log_interval_ms", 10000);  // default: 10000 ms = 10 s
+    interval_sec_ = 1.0 / throttle_hz_;
+
+    last_time_ = this->now();
+
+    auto qos = rclcpp::QoS(rclcpp::KeepLast(10));
+
+    if (compressed_) {
+      // CompressedImage
+      sub_ = create_subscription<CompressedImage>(
+        input_topic_, qos,
+        [this](const CompressedImage::SharedPtr msg) {
+          this->process_message(msg);
+        });
+      pub_ = create_publisher<CompressedImage>(output_topic_, qos);
+    } else {
+      // Image
+      sub_ = create_subscription<Image>(
+        input_topic_, qos,
+        [this](const Image::SharedPtr msg) {
+          this->process_message(msg);
+        });
+      pub_ = create_publisher<Image>(output_topic_, qos);
+    }
+  }
+
+private:
+  void process_message(const std::any & msg)
+  {
+    const auto & now = this->now();
+    if (last_time_ > now) {
+      RCLCPP_WARN(
+        get_logger(), "Detected jump back in time, resetting throttle period to now for.");
+      last_time_ = now;
+      // reset counter
+      total_count_ = 0;
+      grid_count_ = 0;
+      pub_count_ = 0;
+    }
+
+    bool published = false;
+    total_count_++;
+    double last_s = static_cast<double>(last_time_.seconds());
+    double grid_last = std::floor(last_s / interval_sec_) * interval_sec_;
+
+    if (msg.type() == typeid(CompressedImage::SharedPtr)) {
+      CompressedImage::SharedPtr image = std::any_cast<CompressedImage::SharedPtr>(msg);
+      rclcpp::Time t_stamp(image->header.stamp);
+      double stamp_s = static_cast<double>(t_stamp.seconds());
+      double grid_stamp = std::floor(stamp_s / interval_sec_) * interval_sec_;
+      if (grid_stamp != grid_last) {
+        grid_count_++;
+        if (stamp_s - grid_stamp < max_sync_interval_) {
+          pub_count_++;
+          std::static_pointer_cast<rclcpp::Publisher<CompressedImage>>(pub_)->publish(*image);
+          published = true;
+        }
+        last_time_ = t_stamp;
+      }
+    } else if (msg.type() == typeid(Image::SharedPtr)) {
+      Image::SharedPtr image = std::any_cast<Image::SharedPtr>(msg);
+      rclcpp::Time t_stamp(image->header.stamp);
+      double stamp_s = static_cast<double>(t_stamp.seconds());
+      double grid_stamp = std::floor(stamp_s / interval_sec_) * interval_sec_;
+      if (grid_stamp != grid_last) {
+        grid_count_++;
+        if (stamp_s - grid_stamp < max_sync_interval_) {
+          pub_count_++;
+          std::static_pointer_cast<rclcpp::Publisher<Image>>(pub_)->publish(*image);
+          published = true;
+        }
+        last_time_ = t_stamp;
+      }
+    }
+    latest_any_ = msg;
+
+    if (published) {
+      double pub_rate = static_cast<double>(pub_count_) / total_count_;
+      double sync_rate = static_cast<double>(pub_count_) / grid_count_;
+      RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), log_interval_ms_, " publish rate = %f, sync rate = %f.", pub_rate, sync_rate);
+    }
+  }
+
+  rclcpp::PublisherBase::SharedPtr pub_;
+  rclcpp::SubscriptionBase::SharedPtr sub_;
+
+  bool compressed_;
+  double max_sync_interval_;
+  double throttle_hz_;
+  double interval_sec_;
+  int log_interval_ms_;
+  std::string input_topic_;
+  std::string output_topic_;
+  int total_count_ = 0;
+  int grid_count_ = 0;
+  int pub_count_ = 0;
+
+  rclcpp::Time last_time_;
+  std::any latest_any_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<GridImageThrottleNode>(rclcpp::NodeOptions()));
+  rclcpp::shutdown();
+  return 0;
+}

--- a/cabot_common/src/grid_throttle.cpp
+++ b/cabot_common/src/grid_throttle.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2025  IBM Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <cmath>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+#include "topic_tools/tool_base_node.hpp"
+#include "topic_tools/visibility_control.h"
+
+namespace topic_tools
+{
+class GridThrottleNode final : public ToolBaseNode
+{
+  using Sent = std::pair<double, size_t>;
+
+public:
+  TOPIC_TOOLS_PUBLIC
+  explicit GridThrottleNode(const rclcpp::NodeOptions & options)
+  : ToolBaseNode("grid_throttle", options)
+  {
+    input_topic_ = declare_parameter<std::string>("input_topic");
+    output_topic_ = declare_parameter<std::string>("output_topic", input_topic_ + "_throttle");
+    lazy_ = declare_parameter<bool>("lazy", false);
+    throttle_hz_ = declare_parameter<double>("throttle_hz", 1.0);
+    period_ = rclcpp::Rate(throttle_hz_).period();
+    interval_sec_ = 1.0 / throttle_hz_;
+
+    last_time_ = this->now();
+
+    discovery_timer_ = this->create_wall_timer(
+      discovery_period_,
+      std::bind(&GridThrottleNode::make_subscribe_unsubscribe_decisions, this));
+
+    make_subscribe_unsubscribe_decisions();
+  }
+
+private:
+  void process_message(std::shared_ptr<rclcpp::SerializedMessage> msg)
+  {
+    std::scoped_lock lock(pub_mutex_);
+    if (!pub_) {
+      return;
+    }
+
+    const auto & now = this->now();
+    if (last_time_ > now) {
+      RCLCPP_WARN(
+        get_logger(), "Detected jump back in time, resetting throttle period to now for.");
+      last_time_ = now;
+    }
+
+    double now_s = static_cast<double>(now.nanoseconds()) * 1e-9;
+    double grid_now = std::floor(now_s / interval_sec_) * interval_sec_;
+
+    double last_s = static_cast<double>(last_time_.nanoseconds()) * 1e-9;
+    double grid_last = std::floor(last_s / interval_sec_) * interval_sec_;
+
+    if (grid_now != grid_last) {
+      pub_->publish(*msg);
+      last_time_ = now;
+    }
+  }
+
+  double throttle_hz_;
+  double interval_sec_;
+  std::chrono::nanoseconds period_;
+  rclcpp::Time last_time_;
+};
+}  // namespace topic_tools
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<topic_tools::GridThrottleNode>(rclcpp::NodeOptions()));
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This pull requests add grid_image_throttle node that throttles image topics (Image or CompressedImage type) based on header timestamp.
The node is intended to be used to record down-sampled image data to ROS bag to reduce bag file size.